### PR TITLE
Add configurable debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Athene
+
+This project contains a small Flask application that serves the files from the
+`static` directory. It is intended for quickly testing the Leaflet front end.
+
+## Running
+
+Install the dependencies and start the server:
+
+```bash
+pip install Flask
+python app.py
+```
+
+### Debug mode
+
+The Flask debug mode can be toggled by setting the `DEBUG` environment
+variable. When `DEBUG` is set to a truthy value (`1`, `true`, `yes` or
+`on`), the server starts with `debug=True`.
+
+```bash
+DEBUG=1 python app.py  # start with debug mode enabled
+```

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 # app.py – einfacher Webserver zum Servieren der Leaflet-Anwendung
 from flask import Flask, send_from_directory
+import os
 
 app = Flask(__name__, static_folder='static')
 
@@ -11,5 +12,7 @@ def index():
 def serve_file(path):
     return send_from_directory(app.static_folder, path)
 
+DEBUG = os.getenv('DEBUG', 'False').lower() in ('1', 'true', 'yes', 'on')
+
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=DEBUG)


### PR DESCRIPTION
## Summary
- allow configuring Flask debug mode via `DEBUG` environment variable
- document the new `DEBUG` option in `README`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68728184da00833186450b1a1e16890c