### PR TITLE
Add unit selection and keyboard control

### DIFF
--- a/static/ground_asset.js
+++ b/static/ground_asset.js
@@ -4,13 +4,26 @@ export function createGroundAsset(map, position) {
     iconSize: [32, 32]
   });
 
-  const marker = L.marker(position, { icon }).addTo(map).bindPopup("Bodenfahrzeug");
+  const marker = L.marker(position, { icon, draggable: true }).addTo(map).bindPopup('Bodenfahrzeug');
 
   const asset = {
     marker,
     interval: null,
+    onSelect: null,
     moveTo: (target) => moveGroundTo(marker, target, asset)
   };
+
+  marker.on('click', () => {
+    if (asset.onSelect) asset.onSelect(asset);
+  });
+
+  marker.on('dragstart', () => {
+    if (asset.interval) clearInterval(asset.interval);
+  });
+
+  marker.on('dragend', () => {
+    if (asset.onDragEnd) asset.onDragEnd(asset);
+  });
 
   return asset;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -68,6 +68,17 @@
 
     const groundAssets = [];
     let counter = 1;
+    let selectedAsset = null;
+
+    function selectAsset(asset) {
+      selectedAsset = asset;
+      groundAssets.forEach(a => {
+        a.marker.setOpacity(a === asset ? 1 : 0.6);
+      });
+      const idx = groundAssets.indexOf(asset);
+      if (idx >= 0) vehicleSelect.value = idx;
+      asset.marker.openPopup();
+    }
 
     function updateDropdown() {
       vehicleSelect.innerHTML = '';
@@ -82,8 +93,11 @@
     addBtn.onclick = () => {
       const asset = createGroundAsset(map, [48.775 + Math.random() * 0.002, 9.182 + Math.random() * 0.002]);
       asset.id = counter++;
+      asset.onSelect = selectAsset;
+      asset.onDragEnd = selectAsset;
       groundAssets.push(asset);
       updateDropdown();
+      selectAsset(asset);
     };
 
     removeBtn.onclick = () => {
@@ -94,18 +108,63 @@
       clearInterval(asset.interval);
       groundAssets.splice(selectedIndex, 1);
       updateDropdown();
+      selectedAsset = null;
     };
 
     layerSelect.onchange = (e) => {
       switchBaseLayer(e.target.value);
     };
 
+    vehicleSelect.onchange = () => {
+      const idx = parseInt(vehicleSelect.value);
+      if (!isNaN(idx)) {
+        selectAsset(groundAssets[idx]);
+      }
+    };
+
     map.on('click', (e) => {
-  moveAirTo(plane, e.latlng);
-  groundAssets.forEach(asset => {
-    asset.moveTo(e.latlng);
-  });
-});
+      moveAirTo(plane, e.latlng);
+      groundAssets.forEach(asset => {
+        asset.moveTo(e.latlng);
+      });
+    });
+
+    window.addEventListener('keydown', (e) => {
+      if (!selectedAsset) return;
+      const step = 0.0003;
+      const pos = selectedAsset.marker.getLatLng();
+      let changed = false;
+      switch (e.key) {
+        case 'ArrowUp':
+        case 'w':
+        case 'W':
+          pos.lat += step;
+          changed = true;
+          break;
+        case 'ArrowDown':
+        case 's':
+        case 'S':
+          pos.lat -= step;
+          changed = true;
+          break;
+        case 'ArrowLeft':
+        case 'a':
+        case 'A':
+          pos.lng -= step;
+          changed = true;
+          break;
+        case 'ArrowRight':
+        case 'd':
+        case 'D':
+          pos.lng += step;
+          changed = true;
+          break;
+      }
+      if (changed) {
+        selectedAsset.marker.setLatLng(pos);
+        e.preventDefault();
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow selecting a ground unit
- highlight selected unit and keep dropdown in sync
- enable drag&drop on unit markers
- add keyboard controls (WASD/arrow keys) to move the selected unit

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68728a9b09c48331abce68eaefdcaa5f