### PR TITLE
Enable target assignment and pathfinder routing

### DIFF
--- a/static/air_asset.js
+++ b/static/air_asset.js
@@ -3,19 +3,50 @@ let airInterval = null;
 export function initAirAsset(map) {
   const icon = L.icon({
     iconUrl: 'https://cdn-icons-png.flaticon.com/512/684/684908.png',
-    iconSize: [32, 32]
+    iconSize: [32, 32],
+    className: 'unit-icon'
   });
-  const marker = L.marker([48.7758, 9.1829], { icon }).addTo(map).bindPopup("Fluggerät");
-  return marker;
+  const marker = L.marker([48.7758, 9.1829], { icon }).addTo(map).bindPopup('Fluggerät');
+  const asset = {
+    marker,
+    interval: null,
+    pathLine: null,
+    target: null,
+    targetMarker: null,
+    isAir: true,
+    moveTo: (target) => moveAirTo(marker, target, asset),
+    onSelect: null,
+    onDragEnd: null,
+  };
+
+  marker.on('click', () => {
+    if (asset.onSelect) asset.onSelect(asset);
+  });
+
+  return asset;
 }
 
-export function moveAirTo(marker, target) {
+export function moveAirTo(marker, target, asset) {
   if (airInterval) clearInterval(airInterval);
+
+  const map = marker._map;
+  if (asset.pathLine) {
+    map.removeLayer(asset.pathLine);
+  }
+
+  asset.target = target;
+  asset.pathLine = L.polyline([marker.getLatLng(), target], { color: 'red' }).addTo(map);
 
   airInterval = setInterval(() => {
     const next = moveTowards(marker.getLatLng(), target, 0.0012);
     marker.setLatLng(next);
-    if (next.lat === target.lat && next.lng === target.lng) clearInterval(airInterval);
+    if (next.lat === target.lat && next.lng === target.lng) {
+      clearInterval(airInterval);
+      if (asset.pathLine) {
+        map.removeLayer(asset.pathLine);
+        asset.pathLine = null;
+      }
+    }
   }, 100);
 }
 

--- a/static/ground_asset.js
+++ b/static/ground_asset.js
@@ -1,16 +1,35 @@
 export function createGroundAsset(map, position) {
   const icon = L.icon({
     iconUrl: 'https://cdn-icons-png.flaticon.com/512/148/148767.png',
-    iconSize: [32, 32]
+    iconSize: [32, 32],
+    className: 'unit-icon'
   });
 
-  const marker = L.marker(position, { icon }).addTo(map).bindPopup("Bodenfahrzeug");
+  const marker = L.marker(position, { icon, draggable: true }).addTo(map).bindPopup('Bodenfahrzeug');
 
   const asset = {
     marker,
     interval: null,
+    pathLine: null,
+    target: null,
+    targetMarker: null,
+    isAir: false,
+    onSelect: null,
+    onDragEnd: null,
     moveTo: (target) => moveGroundTo(marker, target, asset)
   };
+
+  marker.on('click', () => {
+    if (asset.onSelect) asset.onSelect(asset);
+  });
+
+  marker.on('dragstart', () => {
+    if (asset.interval) clearInterval(asset.interval);
+  });
+
+  marker.on('dragend', () => {
+    if (asset.onDragEnd) asset.onDragEnd(asset);
+  });
 
   return asset;
 }
@@ -21,6 +40,12 @@ function moveGroundTo(marker, target, asset) {
 
   const map = marker._map;
 
+  if (asset.pathLine) {
+    map.removeLayer(asset.pathLine);
+  }
+
+  asset.target = target;
+
   const control = L.Routing.control({
     waypoints: [marker.getLatLng(), target],
     createMarker: () => null,
@@ -29,10 +54,15 @@ function moveGroundTo(marker, target, asset) {
   }).on('routesfound', function (e) {
     map.removeControl(control);  // sauber entfernen
     const coords = e.routes[0].coordinates;
+    asset.pathLine = L.polyline(coords, { color: 'blue' }).addTo(map);
     let i = 0;
     asset.interval = setInterval(() => {
       if (i >= coords.length) {
         clearInterval(asset.interval);
+        if (asset.pathLine) {
+          map.removeLayer(asset.pathLine);
+          asset.pathLine = null;
+        }
         return;
       }
       marker.setLatLng(coords[i]);

--- a/static/index.html
+++ b/static/index.html
@@ -31,6 +31,10 @@
       gap: 8px;
       align-items: center;
     }
+
+    .unit-icon.selected-marker {
+      filter: hue-rotate(310deg) saturate(6) brightness(1.2);
+    }
   </style>
 </head>
 <body>
@@ -44,8 +48,10 @@
     </select>
 
     <select id="vehicle-select"></select>
+    <select id="enemy-select"></select>
     <button id="add-vehicle">+ Fahrzeug</button>
     <button id="remove-vehicle">– Fahrzeug</button>
+    <button id="pathfind">Pfadfinder</button>
   </div>
 
   <div id="map"></div>
@@ -55,19 +61,54 @@
 
   <script type="module">
     import { initMap, switchBaseLayer } from '/map_core.js';
-    import { initAirAsset, moveAirTo } from '/air_asset.js';
+    import { initAirAsset } from '/air_asset.js';
     import { createGroundAsset } from '/ground_asset.js';
 
     const map = initMap();
     const plane = initAirAsset(map);
+    plane.onSelect = selectAsset;
+
+    const enemyAssets = [plane];
 
     const layerSelect = document.getElementById('layer-select');
     const vehicleSelect = document.getElementById('vehicle-select');
+    const enemySelect = document.getElementById('enemy-select');
     const addBtn = document.getElementById('add-vehicle');
     const removeBtn = document.getElementById('remove-vehicle');
+    const pathBtn = document.getElementById('pathfind');
 
     const groundAssets = [];
     let counter = 1;
+    let selectedAsset = null;
+
+    function selectAsset(asset) {
+      if (selectedAsset && selectedAsset.marker.getElement()) {
+        selectedAsset.marker.getElement().classList.remove('selected-marker');
+      }
+      selectedAsset = asset;
+      [...groundAssets, ...enemyAssets].forEach(a => {
+        const el = a.marker.getElement();
+        if (!el) return;
+        if (a === asset) {
+          el.classList.add('selected-marker');
+        } else {
+          el.classList.remove('selected-marker');
+        }
+      });
+
+      const idx = groundAssets.indexOf(asset);
+      if (idx >= 0) {
+        vehicleSelect.value = idx;
+        enemySelect.value = '';
+      } else {
+        const eIdx = enemyAssets.indexOf(asset);
+        if (eIdx >= 0) {
+          enemySelect.value = eIdx;
+          vehicleSelect.value = '';
+        }
+      }
+      asset.marker.openPopup();
+    }
 
     function updateDropdown() {
       vehicleSelect.innerHTML = '';
@@ -77,13 +118,26 @@
         opt.textContent = `Fahrzeug ${a.id}`;
         vehicleSelect.appendChild(opt);
       });
+
+      enemySelect.innerHTML = '';
+      enemyAssets.forEach((a, i) => {
+        const opt = document.createElement('option');
+        opt.value = i;
+        opt.textContent = `Feind ${i + 1}`;
+        enemySelect.appendChild(opt);
+      });
     }
+
+    updateDropdown();
 
     addBtn.onclick = () => {
       const asset = createGroundAsset(map, [48.775 + Math.random() * 0.002, 9.182 + Math.random() * 0.002]);
       asset.id = counter++;
+      asset.onSelect = selectAsset;
+      asset.onDragEnd = selectAsset;
       groundAssets.push(asset);
       updateDropdown();
+      selectAsset(asset);
     };
 
     removeBtn.onclick = () => {
@@ -92,20 +146,86 @@
       const asset = groundAssets[selectedIndex];
       map.removeLayer(asset.marker);
       clearInterval(asset.interval);
+      if (asset.pathLine) map.removeLayer(asset.pathLine);
+      if (asset.targetMarker) map.removeLayer(asset.targetMarker);
       groundAssets.splice(selectedIndex, 1);
       updateDropdown();
+      selectedAsset = null;
     };
 
     layerSelect.onchange = (e) => {
       switchBaseLayer(e.target.value);
     };
 
+    vehicleSelect.onchange = () => {
+      const idx = parseInt(vehicleSelect.value);
+      if (!isNaN(idx)) {
+        selectAsset(groundAssets[idx]);
+      }
+    };
+
+    enemySelect.onchange = () => {
+      const idx = parseInt(enemySelect.value);
+      if (!isNaN(idx)) {
+        selectAsset(enemyAssets[idx]);
+      }
+    };
+
+    pathBtn.onclick = () => {
+      if (!selectedAsset || !selectedAsset.target) return;
+      selectedAsset.moveTo(selectedAsset.target);
+    };
+
     map.on('click', (e) => {
-  moveAirTo(plane, e.latlng);
-  groundAssets.forEach(asset => {
-    asset.moveTo(e.latlng);
-  });
-});
+      if (!selectedAsset) return;
+      selectedAsset.target = e.latlng;
+      const flagIcon = L.icon({
+        iconUrl: 'https://cdn-icons-png.flaticon.com/512/2991/2991148.png',
+        iconSize: [24, 24]
+      });
+      if (selectedAsset.targetMarker) {
+        selectedAsset.targetMarker.setLatLng(e.latlng);
+      } else {
+        selectedAsset.targetMarker = L.marker(e.latlng, { icon: flagIcon }).addTo(map);
+      }
+    });
+
+    window.addEventListener('keydown', (e) => {
+      if (!selectedAsset) return;
+      const step = 0.0003;
+      const pos = selectedAsset.marker.getLatLng();
+      let changed = false;
+      switch (e.key) {
+        case 'ArrowUp':
+        case 'w':
+        case 'W':
+          pos.lat += step;
+          changed = true;
+          break;
+        case 'ArrowDown':
+        case 's':
+        case 'S':
+          pos.lat -= step;
+          changed = true;
+          break;
+        case 'ArrowLeft':
+        case 'a':
+        case 'A':
+          pos.lng -= step;
+          changed = true;
+          break;
+        case 'ArrowRight':
+        case 'd':
+        case 'D':
+          pos.lng += step;
+          changed = true;
+          break;
+      }
+      if (changed) {
+        selectedAsset.marker.setLatLng(pos);
+        e.preventDefault();
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- track targets and paths for each asset
- show a flag marker when a unit target is chosen on the map
- start pathfinding via new "Pfadfinder" button
- draw the resulting route for ground units and a straight line for air assets

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68728a9b09c48331abce68eaefdcaa5f