### PR TITLE
Enable per-asset targeting

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -168,12 +168,6 @@
       }
     });
 
-    map.on('click', (e) => {
-      groundAssets.forEach(asset => {
-        asset.moveTo(e.latlng);
-      });
-    });
-
     window.addEventListener('keydown', (e) => {
       if (!selectedAsset) return;
       const step = 0.0003;


### PR DESCRIPTION
## Summary
- allow setting targets per asset by removing global click listener

## Testing
- `python -m py_compile app.py`
- `node --check static/ground_asset.js`
- `node --check static/map_core.js`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6872ac85c04883318f3852928ab333db